### PR TITLE
Update README.md

### DIFF
--- a/02-Custom-Login/README.md
+++ b/02-Custom-Login/README.md
@@ -35,7 +35,6 @@ import Auth0 from 'auth0-js'
 
 export default class AuthService {
   constructor(clientId, domain) {
-    super()
     // Configure Auth0
     this.auth0 = new Auth0({
       clientID: clientId,


### PR DESCRIPTION
There is no way this Service to run super() because there is no heritage. You should be copying it from the real /src example where it extends from EventEmitter.
