### PR TITLE
JwtHelper: Removed unnecessary offset seconds

### DIFF
--- a/01-Login/src/utils/jwtHelper.js
+++ b/01-Login/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/02-Custom-Login/src/utils/jwtHelper.js
+++ b/02-Custom-Login/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/03-Session-Handling/src/utils/jwtHelper.js
+++ b/03-Session-Handling/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/04-User-Profile/src/utils/jwtHelper.js
+++ b/04-User-Profile/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/05-Linking-Accounts/src/utils/jwtHelper.js
+++ b/05-Linking-Accounts/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/06-Rules/src/utils/jwtHelper.js
+++ b/06-Rules/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/07-Authorization/src/utils/jwtHelper.js
+++ b/07-Authorization/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/08-Calling-Api/src/utils/jwtHelper.js
+++ b/08-Calling-Api/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/09-MFA/src/utils/jwtHelper.js
+++ b/09-MFA/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }

--- a/10-Customizing-Lock/src/utils/jwtHelper.js
+++ b/10-Customizing-Lock/src/utils/jwtHelper.js
@@ -13,9 +13,8 @@ export function getTokenExpirationDate(token){
 
 export function isTokenExpired(token){
   const date = getTokenExpirationDate(token)
-  const offsetSeconds = 0
   if (date === null) {
     return false
   }
-  return !(date.valueOf() > (new Date().valueOf() + (offsetSeconds * 1000)))
+  return !(date.valueOf() > new Date().valueOf())
 }


### PR DESCRIPTION
`offsetSeconds` is always `0`. Perhaps it's meant to be a placeholder but I would recommend getting rid of it, if it's not used and has no impact.