### PR TITLE
Switch from HashHistory to BrowserHistory

### DIFF
--- a/00-Starter-Seed/src/app.js
+++ b/00-Starter-Seed/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/01-Login/src/app.js
+++ b/01-Login/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/01-Login/src/utils/AuthService.js
+++ b/01-Login/src/utils/AuthService.js
@@ -7,7 +7,12 @@ export default class AuthService extends EventEmitter {
   constructor(clientId, domain) {
     super()
     // Configure Auth0
-    this.lock = new Auth0Lock(clientId, domain, {})
+    this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      }
+    })
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', this._doAuthentication.bind(this))
     // Add callback for lock `authorization_error` event
@@ -20,7 +25,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/01-Login/src/views/Main/routes.js
+++ b/01-Login/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/02-Custom-Login/src/app.js
+++ b/02-Custom-Login/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/02-Custom-Login/src/utils/AuthService.js
+++ b/02-Custom-Login/src/utils/AuthService.js
@@ -9,7 +9,8 @@ export default class AuthService extends EventEmitter {
     this.auth0 = new Auth0({
       clientID: clientId,
       domain: domain,
-      callbackOnLocationHash: true
+      responseType: 'token',
+      callbackURL: `${window.location.origin}/login`
     });
 
     this.login = this.login.bind(this)

--- a/02-Custom-Login/src/views/Main/routes.js
+++ b/02-Custom-Login/src/views/Main/routes.js
@@ -15,8 +15,10 @@ const requireAuth = (nextState, replace) => {
 }
 
 const parseAuthHash = (nextState, replace) => {
-  auth.parseHash(nextState.location.hash)
-  replace({ pathname: '/' })
+  if (nextState.location.hash) {
+    const results = auth.parseHash(nextState.location.hash)
+    replace({ pathname: '/' })
+  }
 }
 
 export const makeMainRoutes = () => {
@@ -24,8 +26,7 @@ export const makeMainRoutes = () => {
     <Route path="/" component={Container} auth={auth}>
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
-      <Route path="login" component={Login} />
-      <Route path="access_token=:token" onEnter={parseAuthHash} /> //to prevent router errors
+      <Route path="login" component={Login} onEnter={parseAuthHash} />
     </Route>
   )
 }

--- a/03-Session-Handling/src/app.js
+++ b/03-Session-Handling/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/03-Session-Handling/src/utils/AuthService.js
+++ b/03-Session-Handling/src/utils/AuthService.js
@@ -7,7 +7,12 @@ export default class AuthService extends EventEmitter {
   constructor(clientId, domain) {
     super()
     // Configure Auth0
-    this.lock = new Auth0Lock(clientId, domain, {})
+    this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      }
+    })
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', this._doAuthentication.bind(this))
     // Add callback for lock `authorization_error` event
@@ -20,7 +25,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/03-Session-Handling/src/views/Main/routes.js
+++ b/03-Session-Handling/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/04-User-Profile/src/app.js
+++ b/04-User-Profile/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/04-User-Profile/src/utils/AuthService.js
+++ b/04-User-Profile/src/utils/AuthService.js
@@ -9,6 +9,10 @@ export default class AuthService extends EventEmitter {
     this.domain = domain
     // Configure Auth0
     this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      },
       additionalSignUpFields: [{
         name: "address",                              // required
         placeholder: "enter your address",            // required
@@ -30,7 +34,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/04-User-Profile/src/views/Main/routes.js
+++ b/04-User-Profile/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/05-Linking-Accounts/src/app.js
+++ b/05-Linking-Accounts/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/05-Linking-Accounts/src/utils/AuthService.js
+++ b/05-Linking-Accounts/src/utils/AuthService.js
@@ -9,7 +9,12 @@ export default class AuthService extends EventEmitter {
     this.clientId = clientId
     this.domain = domain
     // Configure Auth0
-    this.lock = new Auth0Lock(clientId, domain)
+    this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      }
+    })
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', this._doAuthentication.bind(this))
     // Add callback for lock `authorization_error` event
@@ -26,7 +31,7 @@ export default class AuthService extends EventEmitter {
       // Saves the user token
       this.setToken(authResult.idToken)
       // navigate to the home route
-      browserHistory.replace('/#/home')
+      browserHistory.replace('/home')
       // Async loads the user profile data
       this.lock.getProfile(authResult.idToken, (error, profile) => {
         if (error) {

--- a/05-Linking-Accounts/src/views/Main/routes.js
+++ b/05-Linking-Accounts/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/06-Rules/src/app.js
+++ b/06-Rules/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/06-Rules/src/utils/AuthService.js
+++ b/06-Rules/src/utils/AuthService.js
@@ -8,7 +8,12 @@ export default class AuthService extends EventEmitter {
     super()
     this.domain = domain
     // Configure Auth0
-    this.lock = new Auth0Lock(clientId, domain, {})
+    this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      }
+    })
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', this._doAuthentication.bind(this))
     // Add callback for lock `authorization_error` event
@@ -21,7 +26,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/06-Rules/src/views/Main/routes.js
+++ b/06-Rules/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/07-Authorization/src/app.js
+++ b/07-Authorization/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/07-Authorization/src/utils/AuthService.js
+++ b/07-Authorization/src/utils/AuthService.js
@@ -7,7 +7,12 @@ export default class AuthService extends EventEmitter {
   constructor(clientId, domain) {
     super()
     // Configure Auth0
-    this.lock = new Auth0Lock(clientId, domain, {})
+    this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      }
+    })
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', this._doAuthentication.bind(this))
     // Add callback for lock `authorization_error` event
@@ -20,7 +25,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/07-Authorization/src/views/Main/routes.js
+++ b/07-Authorization/src/views/Main/routes.js
@@ -44,7 +44,6 @@ export const makeMainRoutes = () => {
         <Route path="unauthorized" component={Unauthorized} />
       </Route>
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/08-Calling-Api/src/app.js
+++ b/08-Calling-Api/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/08-Calling-Api/src/utils/AuthService.js
+++ b/08-Calling-Api/src/utils/AuthService.js
@@ -7,7 +7,12 @@ export default class AuthService extends EventEmitter {
   constructor(clientId, domain) {
     super()
     // Configure Auth0
-    this.lock = new Auth0Lock(clientId, domain, {})
+    this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      }
+    })
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', this._doAuthentication.bind(this))
     // Add callback for lock `authorization_error` event
@@ -20,7 +25,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/08-Calling-Api/src/views/Main/routes.js
+++ b/08-Calling-Api/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/09-MFA/src/app.js
+++ b/09-MFA/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/09-MFA/src/utils/AuthService.js
+++ b/09-MFA/src/utils/AuthService.js
@@ -7,7 +7,12 @@ export default class AuthService extends EventEmitter {
   constructor(clientId, domain) {
     super()
     // Configure Auth0
-    this.lock = new Auth0Lock(clientId, domain, {})
+    this.lock = new Auth0Lock(clientId, domain, {
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
+      }
+    })
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', this._doAuthentication.bind(this))
     // Add callback for lock `authorization_error` event
@@ -20,7 +25,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/09-MFA/src/views/Main/routes.js
+++ b/09-MFA/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }

--- a/10-Customizing-Lock/src/app.js
+++ b/10-Customizing-Lock/src/app.js
@@ -6,13 +6,13 @@ import './app.css'
 
 import App from 'containers/App/App'
 
-import {hashHistory} from 'react-router'
+import {browserHistory} from 'react-router'
 import makeRoutes from './routes'
 
 const routes = makeRoutes()
 
 const mountNode = document.querySelector('#root');
 ReactDOM.render(
-  <App history={hashHistory}
+  <App history={browserHistory}
         routes={routes} />,
 mountNode);

--- a/10-Customizing-Lock/src/utils/AuthService.js
+++ b/10-Customizing-Lock/src/utils/AuthService.js
@@ -16,6 +16,10 @@ export default class AuthService extends EventEmitter {
       },
       languageDictionary: {
         title: "My Company"
+      },
+      auth: {
+        redirectUrl: `${window.location.origin}/login`,
+        responseType: 'token'
       }
     })
     // Add callback for lock `authenticated` event
@@ -30,7 +34,7 @@ export default class AuthService extends EventEmitter {
     // Saves the user token
     this.setToken(authResult.idToken)
     // navigate to the home route
-    browserHistory.replace('/#/home')
+    browserHistory.replace('/home')
     // Async loads the user profile data
     this.lock.getProfile(authResult.idToken, (error, profile) => {
       if (error) {

--- a/10-Customizing-Lock/src/views/Main/routes.js
+++ b/10-Customizing-Lock/src/views/Main/routes.js
@@ -20,7 +20,6 @@ export const makeMainRoutes = () => {
       <IndexRedirect to="/home" />
       <Route path="home" component={Home} onEnter={requireAuth} />
       <Route path="login" component={Login} />
-      <Route path="access_token=:token" component={Login} /> //to prevent router errors
     </Route>
   )
 }


### PR DESCRIPTION
- `HashHistory` conflicts with Auth0's token redirect mode
- hjs-dev-server is configured to support Webpack's `historyApiFallback` by default